### PR TITLE
UDPClient/Socket issue

### DIFF
--- a/Device/Get-LifxDevice.ps1
+++ b/Device/Get-LifxDevice.ps1
@@ -19,7 +19,7 @@ function Get-LifxDevice
     #define listener constants
     $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
     $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
-    $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+    $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
     $receivingUdpClient.Client.Blocking = $false
     $receivingUdpClient.DontFragment = $true
     $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Get-LifxDeviceColor.ps1
+++ b/Device/Get-LifxDeviceColor.ps1
@@ -31,7 +31,7 @@ function Get-LifxDeviceColor
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
         $receivingUdpClient = $null
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Get-LifxDevicePower.ps1
+++ b/Device/Get-LifxDevicePower.ps1
@@ -31,7 +31,7 @@ function Get-LifxDevicePower
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
         $receivingUdpClient = $null
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Get-LifxDeviceSetting.ps1
+++ b/Device/Get-LifxDeviceSetting.ps1
@@ -28,7 +28,7 @@ function Get-LifxDeviceSetting
         $Port = "56700"
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Get-LifxDeviceWifi.ps1
+++ b/Device/Get-LifxDeviceWifi.ps1
@@ -30,7 +30,7 @@ function Get-LifxDeviceWifi
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
         $receivingUdpClient = $null
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Initialize-LifxDevice.ps1
+++ b/Device/Initialize-LifxDevice.ps1
@@ -32,7 +32,7 @@ function Initialize-LifxDevice
         $Port = "56700"
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Set-LifxDeviceColor.ps1
+++ b/Device/Set-LifxDeviceColor.ps1
@@ -161,7 +161,7 @@ function Set-LifxDeviceColor
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port)
         $receivingUdpClient = $null
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)

--- a/Device/Set-LifxDevicePower.ps1
+++ b/Device/Set-LifxDevicePower.ps1
@@ -87,7 +87,7 @@ function Set-LifxDevicePower
         
         $localIP = [System.Net.IPAddress]::Parse([System.Net.IPAddress]::Any)
         $RemoteIpEndPoint = New-Object System.Net.IPEndpoint($localIP, $Port) #New-Object System.Net.IPEndpoint([System.Net.IPAddress]::Any, 0)
-        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint) #(, $Port)
+        $receivingUdpClient = New-Object System.Net.Sockets.UDPClient #(, $Port)
         $receivingUdpClient.Client.Blocking = $false
         $receivingUdpClient.DontFragment = $true
         $receivingUdpClient.Client.SetSocketOption([System.Net.Sockets.SocketOptionLevel]::Socket, [System.Net.Sockets.SocketOptionName]::ReuseAddress, $true)


### PR DESCRIPTION
troubleshooting a UDP/socket issue that seems to be resolved by removing the $RemoteEndPoint argument seen in several cmdlets as declared as: New-Object System.Net.Sockets.UDPClient($RemoteIpEndPoint). It does not appear as though this has a negative impact on discovery or issuing subsequent commands.